### PR TITLE
Add AutoML project

### DIFF
--- a/prod/namespaces/automl/iam-policy-members.yaml
+++ b/prod/namespaces/automl/iam-policy-members.yaml
@@ -1,7 +1,7 @@
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
-  name: automl-owners
+  name: automl-owner-andreyvelich
 spec:
   member: user:andrey.velichkevich@gmail.com
   role: roles/owner
@@ -13,7 +13,7 @@ spec:
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
-  name: automl-owners
+  name: automl-owner-gaocegege
 spec:
   member: user:gaoce@caicloud.io
   role: roles/owner
@@ -25,10 +25,22 @@ spec:
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
-  name: automl-owners
+  name: automl-owner-johnugeorge
 spec:
   member: user:johnugeorge109@gmail.com
   role: roles/owner
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: automl
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: automl-editor-ci
+spec:
+  member: serviceAccount:kubeflow-testing@automl.iam.gserviceaccount.com
+  role: roles/editor
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project

--- a/prod/namespaces/automl/iam-policy-members.yaml
+++ b/prod/namespaces/automl/iam-policy-members.yaml
@@ -1,10 +1,10 @@
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
-  name: automl-owner-andreyvelich
+  name: automl-editor-andreyvelich
 spec:
   member: user:andrey.velichkevich@gmail.com
-  role: roles/owner
+  role: roles/editor
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -13,10 +13,10 @@ spec:
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
-  name: automl-owner-gaocegege
+  name: automl-editor-gaocegege
 spec:
   member: user:gaoce@caicloud.io
-  role: roles/owner
+  role: roles/editor
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -25,10 +25,10 @@ spec:
 apiVersion: iam.cnrm.cloud.google.com/v1beta1
 kind: IAMPolicyMember
 metadata:
-  name: automl-owner-johnugeorge
+  name: automl-editor-johnugeorge
 spec:
   member: user:johnugeorge109@gmail.com
-  role: roles/owner
+  role: roles/editor
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project

--- a/prod/namespaces/automl/iam-policy-members.yaml
+++ b/prod/namespaces/automl/iam-policy-members.yaml
@@ -39,7 +39,7 @@ kind: IAMPolicyMember
 metadata:
   name: automl-editor-ci
 spec:
-  member: serviceAccount:kubeflow-testing@automl.iam.gserviceaccount.com
+  member: serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
   role: roles/editor
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1

--- a/prod/namespaces/automl/iam-policy-members.yaml
+++ b/prod/namespaces/automl/iam-policy-members.yaml
@@ -1,0 +1,35 @@
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: automl-owners
+spec:
+  member: user:andrey.velichkevich@gmail.com
+  role: roles/owner
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: automl
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: automl-owners
+spec:
+  member: user:gaoce@caicloud.io
+  role: roles/owner
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: automl
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: automl-owners
+spec:
+  member: user:johnugeorge109@gmail.com
+  role: roles/owner
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: automl

--- a/prod/namespaces/automl/namespace.yaml
+++ b/prod/namespaces/automl/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: automl

--- a/prod/namespaces/automl/project.yaml
+++ b/prod/namespaces/automl/project.yaml
@@ -1,0 +1,14 @@
+# This project is for AutoML test infrastructure
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  annotations:
+    # This should be the kf-community-folder
+    cnrm.cloud.google.com/folder-id: "303324597781"
+    # TODO(jlewi): I think this is required
+    cnrm.cloud.google.com/auto-create-network: "true"
+  name: automl
+spec:
+  name: automl
+  billingAccountRef:
+    external: "01AF53-DC4A1B-4B1AA1"


### PR DESCRIPTION
Related: https://github.com/kubeflow/testing/issues/749.

I added AutoML project and add @andreyvelich, @gaocegege @johnugeorge as owners.

I can see that I should create [`IAMPolicyMember`](https://cloud.google.com/config-connector/docs/reference/resource-docs/iam/iampolicymember) for each owner.
@jlewi Should `metadata.name` be unique here?

@jlewi Do you know how we can give permission for our prow workflow?
As I can see here: https://github.com/kubeflow/katib/blob/master/test/workflows/components/workflows-v1beta1.libsonnet#L36, we set GCP creds via `kubeflow-testing-credentials` secret in CI cluster.



/assign @jlewi 
/cc @gaocegege @johnugeorge 