### PR TITLE
Add dedicate GCP project for training testing infra

### DIFF
--- a/prod/namespaces/training/iam-policy-members.yaml
+++ b/prod/namespaces/training/iam-policy-members.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: training-owner-gaocegege
+spec:
+  member: user:gaoce@caicloud.io
+  role: roles/owner
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: training
+
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: training-owner-jeffwan
+spec:
+  member: "user:seedjeffwan@gmail.com"
+  role: roles/owner
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: training
+
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: training-owner-johnugeorge
+spec:
+  member: user:johnugeorge109@gmail.com
+  role: roles/owner
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: training
+
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: training-owner-terrytangyuan
+spec:
+  member: user:terrytangyuan@gmail.com
+  role: roles/owner
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: training

--- a/prod/namespaces/training/iam-policy-members.yaml
+++ b/prod/namespaces/training/iam-policy-members.yaml
@@ -5,7 +5,7 @@ metadata:
   name: training-owner-gaocegege
 spec:
   member: user:gaoce@caicloud.io
-  role: roles/owner
+  role: roles/editor
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -17,8 +17,8 @@ kind: IAMPolicyMember
 metadata:
   name: training-owner-jeffwan
 spec:
-  member: "user:seedjeffwan@gmail.com"
-  role: roles/owner
+  member: user:seedjeffwan@gmail.com
+  role: roles/editor
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -31,7 +31,7 @@ metadata:
   name: training-owner-johnugeorge
 spec:
   member: user:johnugeorge109@gmail.com
-  role: roles/owner
+  role: roles/editor
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
@@ -44,7 +44,20 @@ metadata:
   name: training-owner-terrytangyuan
 spec:
   member: user:terrytangyuan@gmail.com
-  role: roles/owner
+  role: roles/editor
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: training
+
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: training-editors
+spec:
+  member: serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/editor
   resourceRef:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project

--- a/prod/namespaces/training/namespace.yaml
+++ b/prod/namespaces/training/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: training

--- a/prod/namespaces/training/project.yaml
+++ b/prod/namespaces/training/project.yaml
@@ -1,0 +1,14 @@
+# This project it for Kubeflow Distributed Training test infrastructure
+apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+kind: Project
+metadata:
+  annotations:
+    # This should be the kf-community-folder
+    cnrm.cloud.google.com/folder-id: "303324597781"
+    # TODO(jlewi): I think this is required 
+    cnrm.cloud.google.com/auto-create-network: "true"
+  name: training
+spec:
+  name: training
+  billingAccountRef:
+    external: "01AF53-DC4A1B-4B1AA1"


### PR DESCRIPTION
Add dedicate GCP project for training testing infra. Once new GCP project created, we can switch to use new GCP project for ephemeral clusters. 

/cc @terrytangyuan @johnugeorge @gaocegege 