### PR TITLE
Add necessary roles for CI service account in AutoML project

### DIFF
--- a/prod/namespaces/automl-ci/iam-policy-members.yaml
+++ b/prod/namespaces/automl-ci/iam-policy-members.yaml
@@ -45,3 +45,27 @@ spec:
     apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
     kind: Project
     external: automl-ci
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: automl-builds-editor-ci
+spec:
+  member: serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/cloudbuild.builds.editor
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: automl-ci
+---
+apiVersion: iam.cnrm.cloud.google.com/v1beta1
+kind: IAMPolicyMember
+metadata:
+  name: automl-container-admin-ci
+spec:
+  member: serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com
+  role: roles/container.admin
+  resourceRef:
+    apiVersion: resourcemanager.cnrm.cloud.google.com/v1beta1
+    kind: Project
+    external: automl-ci


### PR DESCRIPTION
We need to add 2 new roles (`roles/cloudbuild.builds.editor` and `roles/container.admin`) for 
`serviceAccount:kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com` to build images and create Kubernetes resources.

/assign @jlewi 
/cc @gaocegege @johnugeorge 